### PR TITLE
Fixing cost/reward for next flip

### DIFF
--- a/src/commands/coinflip.ts
+++ b/src/commands/coinflip.ts
@@ -22,8 +22,8 @@ const sendReward = (msg, user, client, embed) => {
         return embed.setDescription('You do not have enough to coinflip!')
     }
     
-    const nextCost: number = 100 * (2 ** coinflipStreak + 1)
-    const nextReward: number = 100 * (3 ** (coinflipStreak + 1)) + ((coinflipStreak + 1) * 150)
+    const nextCost: number = 100 * (2 ** (coinflipStreak + 1))
+    const nextReward: number = 100 * (3 ** (coinflipStreak)) + ((coinflipStreak + 1) * 150)
     const description: any = {
         reward: `**${name}** just earned $**${currency(reward)}**`,
         streak: `with a streak of **${coinflipStreak + 1}**!`,


### PR DESCRIPTION
Cost formula: Order of operations was screwing over the formula.
Reward formula: The formula had `coinflipStreak - 1` in the current reward, so it should have been `coinflipStreak - 0` in the nextReward formula.