### PR TITLE
Lost streak message

### DIFF
--- a/src/commands/coinflip.ts
+++ b/src/commands/coinflip.ts
@@ -70,8 +70,8 @@ const sendLoss = (msg, user, client, embed) => {
         .setColor(colors.red)
         .setDescription(
             (coinflipStreak)
-                ? `You lost $**${currency(cost)}**!`
-                : 'You lost your streak!'   
+                ? `You lost your streak and $**${currency(cost)}**!`
+                : 'You lost your coinflip.'   
         )
 
     return User.updateOne(userId, {

--- a/src/commands/coinflip.ts
+++ b/src/commands/coinflip.ts
@@ -59,7 +59,7 @@ const sendReward = (msg, user, client, embed) => {
 
 const sendLoss = (msg, user, client, embed) => {
     const { balance, coinflipStreak } = user
-    const cost: number = Math.round(100 * (2 ** coinflipStreak))
+    const cost: number = (coinflipStreak) ? Math.round(100 * (2 ** coinflipStreak)) : 0
     const userId: { discordId: string } = { discordId: msg.author.id }
 
     if (balance < cost) {

--- a/src/commands/coinflip.ts
+++ b/src/commands/coinflip.ts
@@ -71,7 +71,7 @@ const sendLoss = (msg, user, client, embed) => {
         .setDescription(
             (coinflipStreak)
                 ? `You lost your streak and $**${currency(cost)}**!`
-                : 'You lost your coinflip.'   
+                : 'Your streak remains at 0.'   
         )
 
     return User.updateOne(userId, {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -18,7 +18,7 @@ const channels: any = {
     error: ['692123000602099712']
 }
 
-const version: string = '1.4.0'
+const version: string = '1.4.1'
 const prefix: string = '$'
 const devMode: boolean = false
 const logEnabled: boolean = true


### PR DESCRIPTION
The text "You lost your streak!" only shows up when the user did not have a streak to begin with. I propose changing it to say "You lost your coinflip." I moved the "your streak" part to the message where you DO lose a streak. Feel free to edit this if you do not like the wording.